### PR TITLE
Components/brand toegevoegd als een work-around 

### DIFF
--- a/nlds.tokens.json
+++ b/nlds.tokens.json
@@ -1008,940 +1008,1013 @@
       "type": "typography"
     }
   },
-  "common": {
-    "utrecht": {
-      "document": {
-        "background-color": {
-          "value": "{nlds.color.white}",
-          "type": "color"
-        },
-        "color": {
-          "value": "{nlds.color.neutral.12}",
-          "type": "color"
-        },
-        "font-family": {
-          "value": "{nlds.typography.font-family.bodytext}",
-          "type": "fontFamilies"
-        },
-        "font-size": {
-          "value": "{nlds.typography.font-size.md}",
-          "type": "fontSizes"
-        },
-        "font-weight": {
-          "value": "{nlds.typography.font-weight.normal}",
-          "type": "fontWeights"
-        },
-        "line-height": {
-          "value": "{nlds.typography.line-height.md}",
-          "type": "lineHeights"
-        }
-      },
-      "heading": {
-        "font-family": {
-          "value": "{nlds.typography.font-family.heading}",
-          "type": "fontFamilies"
-        },
-        "font-weight": {
-          "value": "{nlds.typography.font-weight.semibold}",
-          "type": "fontWeights"
-        },
-        "color": {
-          "value": "{nlds.color.paars.12}",
-          "type": "color"
-        }
-      },
-      "form-control": {
-        "font-weight": {
-          "value": "{nlds.typography.font-weight.normal}",
-          "type": "fontWeights"
-        },
-        "background-color": {
-          "value": "{nlds.color.white}",
-          "type": "color"
-        },
-        "border-color": {
-          "value": "{nlds.color.neutral.8}",
-          "type": "color"
-        },
-        "border-width": {
-          "value": "{nlds.border-width.sm}",
-          "type": "borderWidth"
-        },
-        "color": {
-          "value": "{nlds.color.neutral.12}",
-          "type": "color"
-        },
-        "disabled": {
-          "background-color": {
-            "value": "{nlds.color.neutral.2}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{nlds.color.neutral.8}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.color.neutral.8}",
-            "type": "color"
-          }
-        },
-        "focus": {
-          "background-color": {
-            "value": "{nlds.color.white}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{nlds.color.black}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.color.black}",
-            "type": "color"
-          },
-          "border-width": {
-            "value": "{nlds.border-width.md}",
-            "type": "borderWidth"
-          }
-        },
-        "invalid": {
-          "background-color": {
-            "value": "{nlds.color.white}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{nlds.color.signal.rood.500}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.color.signal.rood.500}",
-            "type": "color"
-          },
-          "border-width": {
-            "value": "{nlds.border-width.md}",
-            "type": "borderWidth"
-          }
-        },
-        "read-only": {
-          "background-color": {
-            "value": "{nlds.color.neutral.2}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "transparent",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.color.neutral.12}",
-            "type": "color"
-          }
-        },
-        "placeholder": {
-          "color": {
-            "value": "{nlds.color.neutral.9}",
-            "type": "color"
-          }
-        },
-        "border-radius": {
-          "value": "{nlds.border-radius.sm}",
-          "type": "borderRadius"
-        },
-        "font-family": {
-          "value": "{nlds.typography.font-family.heading}",
-          "type": "fontFamilies"
-        },
-        "font-size": {
-          "value": "{nlds.typography.font-size.md}",
-          "type": "fontSizes"
-        },
-        "line-height": {
-          "value": "{nlds.typography.line-height.md}",
-          "type": "lineHeights"
-        },
-        "max-inline-size": {
-          "value": "400px",
-          "type": "sizing"
-        },
-        "padding-block-end": {
-          "value": "{nlds.space.block.snail}",
-          "type": "spacing"
-        },
-        "padding-block-start": {
-          "value": "{nlds.space.block.snail}",
-          "type": "spacing"
-        },
-        "padding-inline-end": {
-          "value": "{nlds.space.inline.snail}",
-          "type": "spacing"
-        },
-        "padding-inline-start": {
-          "value": "{nlds.space.inline.snail}",
-          "type": "spacing"
-        }
-      },
-      "focus": {
-        "background-color": {
-          "value": "{nlds.color.signal.focus}",
-          "type": "color"
-        },
-        "color": {
-          "value": "{nlds.color.black}",
-          "type": "color"
-        },
-        "outline-color": {
-          "value": "{nlds.color.indigo.9}",
-          "type": "color"
-        },
-        "inverse": {
-          "outline-color": {
-            "value": "{nlds.color.white}",
-            "type": "color"
-          }
-        },
-        "outline-offset": {
-          "value": "0",
-          "type": "other"
-        },
-        "outline-style": {
-          "value": "dotted",
-          "type": "other"
-        },
-        "outline-width": {
-          "value": "{nlds.border-width.md}",
-          "type": "borderWidth"
-        }
-      },
-      "pointer-target": {
-        "min-size": {
-          "value": "{nlds.size.md}",
-          "type": "sizing"
-        }
-      },
-      "feedback": {
-        "warning": {
-          "background-color": {
-            "value": "{nlds.color.oranje.2}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{nlds.color.signal.warning.700}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.color.signal.warning.700}",
-            "type": "color"
-          }
-        }
-      }
-    },
+  "components/brand": {
     "nlds": {
-      "root": {
-        "background-color": {
-          "value": "{nlds.color.paars.3}",
-          "type": "color"
-        }
-      },
-      "container": {
-        "border-width": {
-          "value": "{nlds.border-width.sm}",
-          "type": "borderWidth"
-        },
-        "border-color": {
-          "value": "{nlds.color.neutral.7}",
-          "type": "color"
-        }
-      },
-      "line": {
-        "border-width": {
-          "value": "{nlds.border-width.sm}",
-          "type": "borderWidth"
-        },
-        "border-color": {
-          "value": "{nlds.color.neutral.6}",
-          "type": "color"
-        }
-      },
-      "form-control": {
-        "active": {
-          "border-width": {
-            "value": "{nlds.border-width.md}",
-            "type": "borderWidth"
+      "typography": {
+        "font-size": {
+          "sm": {
+            "value": "0.875rem",
+            "type": "fontSizes"
           },
-          "accent-color": {
-            "value": "{nlds.interaction.active.color}",
-            "type": "color"
+          "md": {
+            "value": "1rem",
+            "type": "fontSizes"
           },
-          "background-color": {
-            "value": "{nlds.color.neutral.4}",
-            "type": "color"
+          "lg": {
+            "value": "1.25rem",
+            "type": "fontSizes"
           },
-          "border-color": {
-            "value": "{nlds.color.neutral.8}",
-            "type": "color"
+          "xl": {
+            "value": "1.5rem",
+            "type": "fontSizes"
           },
-          "color": {
-            "value": "{nlds.color.neutral.12}",
-            "type": "color"
+          "2xl": {
+            "value": "2rem",
+            "type": "fontSizes"
+          },
+          "3xl": {
+            "value": "2.5rem",
+            "type": "fontSizes"
+          },
+          "4xl": {
+            "value": "3rem",
+            "type": "fontSizes"
           }
         },
-        "hover": {
-          "border-width": {
-            "value": "{nlds.border-width.md}",
-            "type": "borderWidth"
+        "line-height": {
+          "xs": {
+            "value": "100%",
+            "type": "lineHeights"
           },
-          "accent-color": {
-            "value": "{nlds.interaction.hover.color}",
-            "type": "color"
+          "sm": {
+            "value": "125%",
+            "type": "lineHeights"
           },
-          "background-color": {
-            "value": "{nlds.color.neutral.2}",
-            "type": "color"
+          "md": {
+            "value": "150%",
+            "type": "lineHeights"
           },
-          "border-color": {
-            "value": "{nlds.color.neutral.8}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.color.neutral.12}",
-            "type": "color"
+          "lg": {
+            "value": "200%",
+            "type": "lineHeights"
           }
         },
-        "accent-color": {
-          "value": "{nlds.interaction.color}",
-          "type": "color"
-        },
-        "disabled": {
-          "accent-color": {
-            "value": "# {nlds.color.neutral.8}",
-            "type": "color"
-          }
-        }
-      },
-      "document": {
-        "inverse": {
-          "background-color": {
-            "value": "{nlds.color.paars.12}",
-            "type": "color"
+        "font-weight": {
+          "normal": {
+            "value": "Regular",
+            "type": "fontWeights"
           },
-          "color": {
-            "value": "{nlds.color.neutral.accent}",
-            "type": "color"
-          }
-        },
-        "subtle": {
-          "color": {
-            "value": "{nlds.color.neutral.9}",
-            "type": "color"
-          }
-        },
-        "strong": {
-          "font-weight": {
-            "value": "{nlds.typography.font-weight.semibold}",
+          "semibold": {
+            "value": "SemiBold",
             "type": "fontWeights"
           }
+        },
+        "font-family": {
+          "heading": {
+            "value": "Fira Sans",
+            "type": "fontFamilies"
+          },
+          "bodytext": {
+            "value": "Source Sans Pro",
+            "type": "fontFamilies"
+          },
+          "code": {
+            "value": "Fira Code, Monaco, monospace",
+            "type": "fontFamilies"
+          }
         }
       },
-      "interaction": {
-        "color": {
-          "value": "{nlds.color.indigo.accent}",
+      "color": {
+        "white": {
+          "value": "#ffffff",
           "type": "color"
         },
-        "active": {
-          "color": {
-            "value": "{nlds.color.indigo.9}",
+        "black": {
+          "value": "#000000",
+          "type": "color"
+        },
+        "indigo": {
+          "1": {
+            "value": "#F6F6FF",
+            "type": "color"
+          },
+          "2": {
+            "value": "#EAECFB",
+            "type": "color"
+          },
+          "3": {
+            "value": "#D6DAFB",
+            "type": "color"
+          },
+          "4": {
+            "value": "#BCC2FB",
+            "type": "color"
+          },
+          "5": {
+            "value": "#A1A7F7",
+            "type": "color"
+          },
+          "6": {
+            "value": "#8689F3",
+            "type": "color"
+          },
+          "7": {
+            "value": "#6D69EE",
+            "type": "color"
+          },
+          "8": {
+            "value": "#5854c8",
+            "type": "color"
+          },
+          "9": {
+            "value": "#45439b",
+            "type": "color"
+          },
+          "10": {
+            "value": "#343476",
+            "type": "color"
+          },
+          "11": {
+            "value": "#2a2b59",
+            "type": "color"
+          },
+          "12": {
+            "value": "#1f203e",
+            "type": "color"
+          },
+          "accent": {
+            "value": "#523CD1",
             "type": "color"
           }
         },
-        "hover": {
-          "color": {
-            "value": "{nlds.color.indigo.8}",
-            "type": "color"
-          }
-        }
-      },
-      "icon": {
-        "functional": {
-          "size": {
-            "value": "{nlds.size.icon.md}",
-            "type": "sizing"
-          }
-        },
-        "toptask": {
-          "size": {
-            "value": "{nlds.size.icon.4xl}",
-            "type": "sizing"
-          }
-        }
-      },
-      "feedback": {
-        "informative": {
-          "background-color": {
-            "value": "{nlds.color.blauw.2}",
+        "rood": {
+          "50": {
+            "value": "#FFF8F8",
             "type": "color"
           },
-          "border-color": {
-            "value": "{nlds.color.blauw.8}",
+          "100": {
+            "value": "#FEF0F1",
             "type": "color"
           },
-          "color": {
-            "value": "{nlds.color.blauw.8}",
-            "type": "color"
-          }
-        },
-        "negative": {
-          "background-color": {
-            "value": "{nlds.color.rood.100}",
+          "200": {
+            "value": "#FEE0E1",
             "type": "color"
           },
-          "border-color": {
-            "value": "{nlds.color.signal.rood.500}",
+          "300": {
+            "value": "#FDC7CA",
             "type": "color"
           },
-          "color": {
-            "value": "{nlds.color.signal.rood.500}",
+          "400": {
+            "value": "#F97D83",
+            "type": "color"
+          },
+          "500": {
+            "value": "#F7464E",
+            "type": "color"
+          },
+          "600": {
+            "value": "#D2262E",
+            "type": "color"
+          },
+          "700": {
+            "value": "#A41E24",
+            "type": "color"
+          },
+          "800": {
+            "value": "#7E171C",
+            "type": "color"
+          },
+          "900": {
+            "value": "#500F12",
+            "type": "color"
+          },
+          "950": {
+            "value": "#31090B",
             "type": "color"
           }
         },
-        "positive": {
-          "background-color": {
-            "value": "{nlds.color.groen.2}",
+        "geel": {
+          "1": {
+            "value": "#fef7e5",
             "type": "color"
           },
-          "border-color": {
-            "value": "{nlds.color.signal.groen.500}",
+          "2": {
+            "value": "#fbeabe",
             "type": "color"
           },
-          "color": {
-            "value": "{nlds.color.signal.groen.500}",
+          "3": {
+            "value": "#fade92",
             "type": "color"
+          },
+          "4": {
+            "value": "#f7d062",
+            "type": "color"
+          },
+          "5": {
+            "value": "#ebc03c",
+            "type": "color"
+          },
+          "6": {
+            "value": "#d9af21",
+            "type": "color"
+          },
+          "7": {
+            "value": "#c09b25",
+            "type": "color"
+          },
+          "8": {
+            "value": "#aa8a26",
+            "type": "color"
+          },
+          "9": {
+            "value": "#8f7423",
+            "type": "color"
+          },
+          "10": {
+            "value": "#715b16",
+            "type": "color"
+          },
+          "11": {
+            "value": "#55461a",
+            "type": "color"
+          },
+          "12": {
+            "value": "#342c14",
+            "type": "color"
+          },
+          "accent": {
+            "value": "#fcd940",
+            "type": "color"
+          }
+        },
+        "light": {
+          "alpha": {
+            "50": {
+              "value": "#ffffff",
+              "type": "color"
+            },
+            "100": {
+              "value": "#ffffff1a",
+              "type": "color"
+            }
+          }
+        },
+        "dark": {
+          "alpha": {
+            "50": {
+              "value": "#0000000d",
+              "type": "color"
+            },
+            "100": {
+              "value": "#0000001a",
+              "type": "color"
+            }
+          }
+        },
+        "paars": {
+          "1": {
+            "value": "#FDF4FD",
+            "type": "color"
+          },
+          "2": {
+            "value": "#F8E4F9",
+            "type": "color"
+          },
+          "3": {
+            "value": "#F7D3FB",
+            "type": "color"
+          },
+          "4": {
+            "value": "#EDB5F8",
+            "type": "color"
+          },
+          "5": {
+            "value": "#E49DF4",
+            "type": "color"
+          },
+          "6": {
+            "value": "#D37BE2",
+            "type": "color"
+          },
+          "7": {
+            "value": "#BF63D4",
+            "type": "color"
+          },
+          "8": {
+            "value": "#A54EC0",
+            "type": "color"
+          },
+          "9": {
+            "value": "#8a3a9f",
+            "type": "color"
+          },
+          "10": {
+            "value": "#702d84",
+            "type": "color"
+          },
+          "11": {
+            "value": "#551e68",
+            "type": "color"
+          },
+          "12": {
+            "value": "#42144f",
+            "type": "color"
+          },
+          "accent": {
+            "value": "#F1B5FF",
+            "type": "color"
+          }
+        },
+        "blauw": {
+          "1": {
+            "value": "#F6FAFF",
+            "type": "color"
+          },
+          "2": {
+            "value": "#EDF6FF",
+            "type": "color"
+          },
+          "3": {
+            "value": "#C7E3FF",
+            "type": "color"
+          },
+          "4": {
+            "value": "#A0CEFB",
+            "type": "color"
+          },
+          "5": {
+            "value": "#7BBCF9",
+            "type": "color"
+          },
+          "6": {
+            "value": "#56a7f1",
+            "type": "color"
+          },
+          "7": {
+            "value": "#4598e0",
+            "type": "color"
+          },
+          "8": {
+            "value": "#3585ca",
+            "type": "color"
+          },
+          "9": {
+            "value": "#3273ab",
+            "type": "color"
+          },
+          "10": {
+            "value": "#275d8b",
+            "type": "color"
+          },
+          "11": {
+            "value": "#1f4769",
+            "type": "color"
+          },
+          "12": {
+            "value": "#15314a",
+            "type": "color"
+          },
+          "accent": {
+            "value": "#99CFFF",
+            "type": "color"
+          }
+        },
+        "groen": {
+          "1": {
+            "value": "#F8FFF7",
+            "type": "color"
+          },
+          "2": {
+            "value": "#EFFAEE",
+            "type": "color"
+          },
+          "3": {
+            "value": "#CDEDC7",
+            "type": "color"
+          },
+          "4": {
+            "value": "#A3DF9A",
+            "type": "color"
+          },
+          "5": {
+            "value": "#7ECF72",
+            "type": "color"
+          },
+          "6": {
+            "value": "#5bb74c",
+            "type": "color"
+          },
+          "7": {
+            "value": "#539e47",
+            "type": "color"
+          },
+          "8": {
+            "value": "#427e38",
+            "type": "color"
+          },
+          "9": {
+            "value": "#35662e",
+            "type": "color"
+          },
+          "10": {
+            "value": "#2a4e24",
+            "type": "color"
+          },
+          "11": {
+            "value": "#254121",
+            "type": "color"
+          },
+          "12": {
+            "value": "#1b3017",
+            "type": "color"
+          },
+          "accent": {
+            "value": "#B2F5A7",
+            "type": "color"
+          }
+        },
+        "oranje": {
+          "1": {
+            "value": "#fef1e7",
+            "type": "color"
+          },
+          "2": {
+            "value": "#fce4d3",
+            "type": "color"
+          },
+          "3": {
+            "value": "#ffd0ae",
+            "type": "color"
+          },
+          "4": {
+            "value": "#feba85",
+            "type": "color"
+          },
+          "5": {
+            "value": "#fa9a47",
+            "type": "color"
+          },
+          "6": {
+            "value": "#ea8420",
+            "type": "color"
+          },
+          "7": {
+            "value": "#cd710b",
+            "type": "color"
+          },
+          "8": {
+            "value": "#b36519",
+            "type": "color"
+          },
+          "9": {
+            "value": "#945418",
+            "type": "color"
+          },
+          "10": {
+            "value": "#7f4919",
+            "type": "color"
+          },
+          "11": {
+            "value": "#623a17",
+            "type": "color"
+          },
+          "12": {
+            "value": "#4a2e17",
+            "type": "color"
+          },
+          "accent": {
+            "value": "#FFB980",
+            "type": "color"
+          }
+        },
+        "roze": {
+          "1": {
+            "value": "#fff9f9",
+            "type": "color"
+          },
+          "2": {
+            "value": "#FFF3F3",
+            "type": "color"
+          },
+          "3": {
+            "value": "#FFD8D8",
+            "type": "color"
+          },
+          "4": {
+            "value": "#ffbebc",
+            "type": "color"
+          },
+          "5": {
+            "value": "#f69a9a",
+            "type": "color"
+          },
+          "6": {
+            "value": "#f37579",
+            "type": "color"
+          },
+          "7": {
+            "value": "#df535a",
+            "type": "color"
+          },
+          "8": {
+            "value": "#c83d4a",
+            "type": "color"
+          },
+          "9": {
+            "value": "#ac2f3b",
+            "type": "color"
+          },
+          "10": {
+            "value": "#882839",
+            "type": "color"
+          },
+          "11": {
+            "value": "#70212c",
+            "type": "color"
+          },
+          "12": {
+            "value": "#5e1d25",
+            "type": "color"
+          },
+          "accent": {
+            "value": "#FFB8BA",
+            "type": "color"
+          }
+        },
+        "neutral": {
+          "1": {
+            "value": "#f3f7fe",
+            "type": "color"
+          },
+          "2": {
+            "value": "#e6eaf0",
+            "type": "color"
+          },
+          "3": {
+            "value": "#d9dce2",
+            "type": "color"
+          },
+          "4": {
+            "value": "#c9ccd2",
+            "type": "color"
+          },
+          "5": {
+            "value": "#b4b7bd",
+            "type": "color"
+          },
+          "6": {
+            "value": "#9ea2a7",
+            "type": "color"
+          },
+          "7": {
+            "value": "#85888e",
+            "type": "color"
+          },
+          "8": {
+            "value": "#696c71",
+            "type": "color"
+          },
+          "9": {
+            "value": "#585b60",
+            "type": "color"
+          },
+          "10": {
+            "value": "#45484d",
+            "type": "color"
+          },
+          "11": {
+            "value": "#303338",
+            "type": "color"
+          },
+          "12": {
+            "value": "#1d1f24",
+            "type": "color"
+          },
+          "accent": {
+            "value": "#FDFDFD",
+            "type": "color"
+          }
+        },
+        "signal": {
+          "focus": {
+            "value": "#A6FF00",
+            "type": "color"
+          },
+          "groen": {
+            "500": {
+              "value": "#009D12",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "700": {
+              "value": "#C45500",
+              "type": "color"
+            }
+          },
+          "rood": {
+            "500": {
+              "value": "#e5033b",
+              "type": "color"
+            }
           }
         }
       },
       "space": {
-        "relation": {
-          "kind": {
-            "value": "0px",
-            "type": "dimension"
+        "inline": {
+          "flea": {
+            "value": "2px",
+            "type": "spacing"
           },
-          "besties": {
-            "value": "{nlds.space.row.snail}",
-            "type": "dimension"
+          "ant": {
+            "value": "4px",
+            "type": "spacing"
           },
-          "vrienden": {
-            "value": "{nlds.space.row.rat}",
-            "type": "dimension"
+          "beetle": {
+            "value": "8px",
+            "type": "spacing"
           },
-          "bekenden": {
-            "value": "{nlds.space.row.cat}",
-            "type": "dimension"
+          "snail": {
+            "value": "12px",
+            "type": "spacing"
           },
-          "onbekenden": {
-            "value": "{nlds.space.row.pig}",
-            "type": "dimension"
+          "mouse": {
+            "value": "16px",
+            "type": "spacing"
           },
-          "onbemind": {
-            "value": "{nlds.space.row.horse}",
-            "type": "dimension"
+          "rat": {
+            "value": "20px",
+            "type": "spacing"
+          },
+          "rabbit": {
+            "value": "24px",
+            "type": "spacing"
+          },
+          "cat": {
+            "value": "28px",
+            "type": "spacing"
+          },
+          "dog": {
+            "value": "32px",
+            "type": "spacing"
+          },
+          "pig": {
+            "value": "48px",
+            "type": "spacing"
+          }
+        },
+        "block": {
+          "flea": {
+            "value": "2px",
+            "type": "spacing"
+          },
+          "ant": {
+            "value": "4px",
+            "type": "spacing"
+          },
+          "beetle": {
+            "value": "8px",
+            "type": "spacing"
+          },
+          "snail": {
+            "value": "12px",
+            "type": "spacing"
+          },
+          "mouse": {
+            "value": "16px",
+            "type": "spacing"
+          },
+          "rat": {
+            "value": "20px",
+            "type": "spacing"
+          },
+          "rabbit": {
+            "value": "24px",
+            "type": "spacing"
+          },
+          "cat": {
+            "value": "32px",
+            "type": "spacing"
+          },
+          "dog": {
+            "value": "48px",
+            "type": "spacing"
+          },
+          "pig": {
+            "value": "64px",
+            "type": "spacing"
+          }
+        },
+        "text": {
+          "flea": {
+            "value": "1px",
+            "description": "0.125ch",
+            "type": "spacing"
+          },
+          "ant": {
+            "value": "2px",
+            "description": "0.25ch",
+            "type": "spacing"
+          },
+          "beetle": {
+            "value": "4px",
+            "description": "0.5ch",
+            "type": "spacing"
+          },
+          "snail": {
+            "value": "6px",
+            "description": "0.75ch",
+            "type": "spacing"
+          },
+          "mouse": {
+            "value": "8px",
+            "description": "1ch",
+            "type": "spacing"
+          },
+          "rat": {
+            "value": "12px",
+            "description": "1.5ch",
+            "type": "spacing"
+          },
+          "rabbit": {
+            "value": "14px",
+            "description": "1.75ch",
+            "type": "spacing"
+          },
+          "cat": {
+            "value": "16px",
+            "description": "2ch",
+            "type": "spacing"
+          },
+          "dog": {
+            "value": "24px",
+            "description": "3ch",
+            "type": "spacing"
+          }
+        },
+        "column": {
+          "flea": {
+            "value": "1px",
+            "type": "spacing"
+          },
+          "ant": {
+            "value": "2px",
+            "type": "spacing"
+          },
+          "beetle": {
+            "value": "4px",
+            "type": "spacing"
+          },
+          "snail": {
+            "value": "8px",
+            "type": "spacing"
+          },
+          "mouse": {
+            "value": "12px",
+            "type": "spacing"
+          },
+          "rat": {
+            "value": "16px",
+            "type": "spacing"
+          },
+          "rabbit": {
+            "value": "20px",
+            "type": "spacing"
+          },
+          "cat": {
+            "value": "24px",
+            "type": "spacing"
+          },
+          "dog": {
+            "value": "28px",
+            "type": "spacing"
+          },
+          "pig": {
+            "value": "32px",
+            "type": "spacing"
+          },
+          "tiger": {
+            "value": "48px",
+            "type": "spacing"
+          },
+          "horse": {
+            "value": "64px",
+            "type": "spacing"
+          },
+          "elephant": {
+            "value": "96px",
+            "type": "spacing"
+          },
+          "giraffe": {
+            "value": "160px",
+            "type": "spacing"
+          }
+        },
+        "row": {
+          "flea": {
+            "value": "1px",
+            "type": "spacing"
+          },
+          "ant": {
+            "value": "2px",
+            "type": "spacing"
+          },
+          "beetle": {
+            "value": "4px",
+            "type": "spacing"
+          },
+          "snail": {
+            "value": "8px",
+            "type": "spacing"
+          },
+          "mouse": {
+            "value": "12px",
+            "type": "spacing"
+          },
+          "rat": {
+            "value": "16px",
+            "type": "spacing"
+          },
+          "rabbit": {
+            "value": "20px",
+            "type": "spacing"
+          },
+          "cat": {
+            "value": "24px",
+            "type": "spacing"
+          },
+          "dog": {
+            "value": "28px",
+            "type": "spacing"
+          },
+          "pig": {
+            "value": "32px",
+            "type": "spacing"
+          },
+          "tiger": {
+            "value": "48px",
+            "type": "spacing"
+          },
+          "horse": {
+            "value": "64px",
+            "type": "spacing"
+          },
+          "elephant": {
+            "value": "96px",
+            "type": "spacing"
+          },
+          "giraffe": {
+            "value": "160px",
+            "type": "spacing"
           }
         }
       },
-      "code": {
-        "font-family": {
-          "value": "{nlds.typography.font-family.code}",
-          "type": "fontFamilies"
-        }
-      }
-    }
-  },
-  "components/accordion/utrecht": {
-    "utrecht": {
-      "accordion": {
-        "panel": {
-          "border-color": {
-            "value": "transparent",
-            "type": "color"
-          },
-          "border-width": {
-            "value": "{nlds.border-width.sm}",
-            "type": "borderWidth"
-          },
-          "padding-block-end": {
-            "value": "{nlds.space.block.rabbit}",
-            "type": "spacing"
-          },
-          "padding-block-start": {
-            "value": "{nlds.space.block.rabbit}",
-            "type": "spacing"
-          },
-          "padding-inline-end": {
-            "value": "{nlds.space.inline.mouse}",
-            "type": "spacing"
-          },
-          "padding-inline-start": {
-            "value": "{nlds.space.inline.mouse}",
-            "type": "spacing"
-          }
+      "border-radius": {
+        "sm": {
+          "value": "4px",
+          "type": "borderRadius"
         },
-        "button": {
-          "gap": {
-            "value": "{nlds.space.text.mouse}",
-            "type": "spacing"
+        "md": {
+          "value": "8px",
+          "type": "borderRadius"
+        },
+        "lg": {
+          "value": "16px",
+          "type": "borderRadius"
+        },
+        "round": {
+          "value": "999px",
+          "type": "borderRadius"
+        }
+      },
+      "border-width": {
+        "sm": {
+          "value": "1px",
+          "type": "borderWidth"
+        },
+        "md": {
+          "value": "2px",
+          "type": "borderWidth"
+        },
+        "lg": {
+          "value": "4px",
+          "type": "borderWidth"
+        }
+      },
+      "size": {
+        "5xs": {
+          "value": "2px",
+          "type": "sizing"
+        },
+        "4xs": {
+          "value": "4px",
+          "type": "sizing"
+        },
+        "3xs": {
+          "value": "8px",
+          "type": "sizing"
+        },
+        "2xs": {
+          "value": "16px",
+          "type": "sizing"
+        },
+        "xs": {
+          "value": "24px",
+          "type": "sizing"
+        },
+        "sm": {
+          "value": "32px",
+          "type": "sizing"
+        },
+        "md": {
+          "value": "48px",
+          "type": "sizing"
+        },
+        "lg": {
+          "value": "64px",
+          "type": "sizing"
+        },
+        "xl": {
+          "value": "96px",
+          "type": "sizing"
+        },
+        "2xl": {
+          "value": "160px",
+          "type": "sizing"
+        },
+        "icon": {
+          "sm": {
+            "value": "16px",
+            "type": "sizing"
           },
-          "icon": {
-            "size": {
-              "value": "{nlds.icon.functional.size}",
-              "type": "sizing"
-            }
+          "md": {
+            "value": "24px",
+            "type": "sizing"
           },
-          "padding-block-end": {
-            "value": "{nlds.space.block.snail}",
-            "type": "spacing"
+          "lg": {
+            "value": "24px",
+            "type": "sizing"
           },
-          "padding-block-start": {
-            "value": "{nlds.space.block.snail}",
-            "type": "spacing"
+          "xl": {
+            "value": "24px",
+            "type": "sizing"
           },
-          "padding-inline-end": {
-            "value": "{nlds.space.inline.mouse}",
-            "type": "spacing"
+          "2xl": {
+            "value": "32px",
+            "type": "sizing"
           },
-          "padding-inline-start": {
-            "value": "{nlds.space.inline.mouse}",
-            "type": "spacing"
+          "3xl": {
+            "value": "40px",
+            "type": "sizing"
           },
-          "background-color": {
-            "value": "{nlds.color.neutral.2}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "transparent",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.interaction.color}",
-            "type": "color"
-          },
-          "hover": {
-            "background-color": {
-              "value": "{nlds.color.neutral.4}",
-              "type": "color"
-            },
-            "border-color": {
-              "value": "transparent",
-              "type": "color"
-            },
-            "color": {
-              "value": "{nlds.interaction.hover.color}",
-              "type": "color"
-            }
-          },
-          "focus": {
-            "background-color": {
-              "value": "{nlds.color.signal.focus}",
-              "type": "color"
-            },
-            "border-color": {
-              "value": "transparent",
-              "type": "color"
-            },
-            "color": {
-              "value": "{utrecht.focus.color}",
-              "type": "color"
-            }
-          },
-          "active": {
-            "background-color": {
-              "value": "{nlds.color.indigo.4}",
-              "type": "color"
-            },
-            "border-color": {
-              "value": "transparent",
-              "type": "color"
-            },
-            "color": {
-              "value": "{nlds.interaction.active.color}",
-              "type": "color"
-            }
-          },
-          "border-width": {
-            "value": "{nlds.border-width.sm}",
-            "type": "borderWidth"
-          },
-          "border-radius": {
-            "value": "{nlds.border-radius.sm}",
-            "type": "borderRadius"
+          "4xl": {
+            "value": "48px",
+            "type": "sizing"
           }
         }
-      }
-    },
-    "todo": {
-      "accordion": {
-        "section": {
-          "border-width": {
-            "value": "{nlds.border-width.sm}",
-            "type": "borderWidth"
+      },
+      "box-shadow": {
+        "sm": {
+          "value": {
+            "x": "0",
+            "y": "2",
+            "blur": "6",
+            "spread": "0",
+            "color": "{nlds.color.dark.alpha.100}",
+            "type": "dropShadow"
           },
-          "border-color": {
-            "value": "{nlds.line.border-color}",
-            "type": "color"
-          }
+          "type": "boxShadow"
         },
-        "button": {
-          "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+        "md": {
+          "value": {
+            "x": "0",
+            "y": "8",
+            "blur": "16",
+            "spread": "0",
+            "color": "{nlds.color.dark.alpha.100}",
+            "type": "dropShadow"
           },
-          "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
-          },
-          "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
-          },
-          "font-weight": {
-            "value": "{nlds.document.strong.font-weight}",
-            "type": "fontWeights"
-          }
+          "type": "boxShadow"
         },
-        "row-gap": {
-          "value": "0",
-          "type": "spacing"
-        }
-      }
-    }
-  },
-  "components/accordion/nlds": {
-    "nlds": {
-      "accordion": {
-        "panel": {
-          "border-color": {
-            "value": "{nlds.line.border-color}",
-            "type": "color"
+        "lg": {
+          "value": {
+            "x": "0",
+            "y": "16",
+            "blur": "48",
+            "spread": "0",
+            "color": "{nlds.color.dark.alpha.100}",
+            "type": "dropShadow"
           },
-          "color": {
-            "value": "{nlds.color.neutral.accent}",
-            "type": "color"
-          }
-        },
-        "button": {
-          "help-wanted": {
-            "background-color": {
-              "value": "{nlds.color.oranje.accent}",
-              "type": "color"
-            },
-            "border-color": {
-              "value": "transparent",
-              "type": "color"
-            },
-            "color": {
-              "value": "{nlds.color.oranje.11}",
-              "type": "color"
-            },
-            "hover": {
-              "background-color": {
-                "value": "{nlds.color.oranje.5}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{nlds.color.oranje.12}",
-                "type": "color"
-              }
-            },
-            "focus": {
-              "background-color": {
-                "value": "{nlds.color.signal.focus}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{utrecht.focus.color}",
-                "type": "color"
-              }
-            },
-            "active": {
-              "background-color": {
-                "value": "{nlds.color.oranje.6}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{nlds.color.oranje.12}",
-                "type": "color"
-              }
-            }
-          },
-          "community": {
-            "background-color": {
-              "value": "{nlds.color.paars.accent}",
-              "type": "color"
-            },
-            "border-color": {
-              "value": "transparent",
-              "type": "color"
-            },
-            "color": {
-              "value": "{nlds.color.paars.11}",
-              "type": "color"
-            },
-            "hover": {
-              "background-color": {
-                "value": "{nlds.color.paars.5}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{nlds.color.paars.12}",
-                "type": "color"
-              }
-            },
-            "focus": {
-              "background-color": {
-                "value": "{nlds.color.signal.focus}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{utrecht.focus.color}",
-                "type": "color"
-              }
-            },
-            "active": {
-              "background-color": {
-                "value": "{nlds.color.paars.6}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{nlds.color.paars.12}",
-                "type": "color"
-              }
-            }
-          },
-          "candidate": {
-            "background-color": {
-              "value": "{nlds.color.blauw.accent}",
-              "type": "color"
-            },
-            "border-color": {
-              "value": "transparent",
-              "type": "color"
-            },
-            "color": {
-              "value": "{nlds.color.blauw.11}",
-              "type": "color"
-            },
-            "hover": {
-              "background-color": {
-                "value": "{nlds.color.blauw.5}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{nlds.color.blauw.12}",
-                "type": "color"
-              }
-            },
-            "focus": {
-              "background-color": {
-                "value": "{nlds.color.signal.focus}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{utrecht.focus.color}",
-                "type": "color"
-              }
-            },
-            "active": {
-              "background-color": {
-                "value": "{nlds.color.blauw.6}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{nlds.color.blauw.12}",
-                "type": "color"
-              }
-            }
-          },
-          "hall-of-fame": {
-            "background-color": {
-              "value": "{nlds.color.groen.accent}",
-              "type": "color"
-            },
-            "border-color": {
-              "value": "transparent",
-              "type": "color"
-            },
-            "color": {
-              "value": "{nlds.color.groen.11}",
-              "type": "color"
-            },
-            "hover": {
-              "background-color": {
-                "value": "{nlds.color.groen.5}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{nlds.color.groen.12}",
-                "type": "color"
-              }
-            },
-            "focus": {
-              "background-color": {
-                "value": "{nlds.color.signal.focus}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{utrecht.focus.color}",
-                "type": "color"
-              }
-            },
-            "active": {
-              "background-color": {
-                "value": "{nlds.color.groen.6}",
-                "type": "color"
-              },
-              "border-color": {
-                "value": "transparent",
-                "type": "color"
-              },
-              "color": {
-                "value": "{nlds.color.groen.12}",
-                "type": "color"
-              }
-            }
-          },
-          "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
-          },
-          "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
-          },
-          "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
-          },
-          "font-weight": {
-            "value": "{nlds.document.strong.font-weight}",
-            "type": "fontWeights"
-          }
-        },
-        "section": {
-          "border-width": {
-            "value": "{nlds.border-width.sm}",
-            "type": "borderWidth"
-          },
-          "border-color": {
-            "value": "{nlds.color.neutral.accent}",
-            "type": "color"
-          }
-        },
-        "row-gap": {
-          "value": "0",
-          "type": "spacing"
+          "type": "boxShadow"
         }
       }
     },
-    "utrecht": {
-      "accordion": {
-        "panel": {
-          "border-width": {
-            "value": "{nlds.border-width.sm}",
-            "type": "borderWidth"
-          },
-          "padding-block-end": {
-            "value": "{nlds.space.block.rabbit}",
-            "type": "spacing"
-          },
-          "padding-block-start": {
-            "value": "{nlds.space.block.rabbit}",
-            "type": "spacing"
-          },
-          "padding-inline-end": {
-            "value": "{nlds.space.inline.mouse}",
-            "type": "spacing"
-          },
-          "padding-inline-start": {
-            "value": "{nlds.space.inline.mouse}",
-            "type": "spacing"
-          }
-        },
-        "button": {
-          "gap": {
-            "value": "{nlds.space.text.mouse}",
-            "type": "spacing"
-          },
-          "icon": {
-            "size": {
-              "value": "{nlds.icon.functional.size}",
-              "type": "sizing"
-            }
-          },
-          "padding-block-end": {
-            "value": "{nlds.space.block.snail}",
-            "type": "spacing"
-          },
-          "padding-block-start": {
-            "value": "{nlds.space.block.snail}",
-            "type": "spacing"
-          },
-          "padding-inline-end": {
-            "value": "{nlds.space.inline.mouse}",
-            "type": "spacing"
-          },
-          "padding-inline-start": {
-            "value": "{nlds.space.inline.mouse}",
-            "type": "spacing"
-          },
-          "border-width": {
-            "value": "{nlds.border-width.sm}",
-            "type": "borderWidth"
-          },
-          "border-radius": {
-            "value": "{nlds.border-radius.sm}",
-            "type": "borderRadius"
-          }
-        }
-      }
+    "Fira Sans": {
+      "value": {
+        "fontFamily": "Fira Sans",
+        "fontWeight": "Semibold"
+      },
+      "type": "typography"
     }
   },
   "components/action": {
@@ -5348,6 +5421,450 @@
       }
     }
   },
+  "common": {
+    "utrecht": {
+      "document": {
+        "background-color": {
+          "value": "{nlds.color.white}",
+          "type": "color"
+        },
+        "color": {
+          "value": "{nlds.color.neutral.12}",
+          "type": "color"
+        },
+        "font-family": {
+          "value": "{nlds.typography.font-family.bodytext}",
+          "type": "fontFamilies"
+        },
+        "font-size": {
+          "value": "{nlds.typography.font-size.md}",
+          "type": "fontSizes"
+        },
+        "font-weight": {
+          "value": "{nlds.typography.font-weight.normal}",
+          "type": "fontWeights"
+        },
+        "line-height": {
+          "value": "{nlds.typography.line-height.md}",
+          "type": "lineHeights"
+        }
+      },
+      "heading": {
+        "font-family": {
+          "value": "{nlds.typography.font-family.heading}",
+          "type": "fontFamilies"
+        },
+        "font-weight": {
+          "value": "{nlds.typography.font-weight.semibold}",
+          "type": "fontWeights"
+        },
+        "color": {
+          "value": "{nlds.color.paars.12}",
+          "type": "color"
+        }
+      },
+      "form-control": {
+        "font-weight": {
+          "value": "{nlds.typography.font-weight.normal}",
+          "type": "fontWeights"
+        },
+        "background-color": {
+          "value": "{nlds.color.white}",
+          "type": "color"
+        },
+        "border-color": {
+          "value": "{nlds.color.neutral.8}",
+          "type": "color"
+        },
+        "border-width": {
+          "value": "{nlds.border-width.sm}",
+          "type": "borderWidth"
+        },
+        "color": {
+          "value": "{nlds.color.neutral.12}",
+          "type": "color"
+        },
+        "disabled": {
+          "background-color": {
+            "value": "{nlds.color.neutral.2}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{nlds.color.neutral.8}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.neutral.8}",
+            "type": "color"
+          }
+        },
+        "focus": {
+          "background-color": {
+            "value": "{nlds.color.white}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{nlds.color.black}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.black}",
+            "type": "color"
+          },
+          "border-width": {
+            "value": "{nlds.border-width.md}",
+            "type": "borderWidth"
+          }
+        },
+        "invalid": {
+          "background-color": {
+            "value": "{nlds.color.white}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{nlds.color.signal.rood.500}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.signal.rood.500}",
+            "type": "color"
+          },
+          "border-width": {
+            "value": "{nlds.border-width.md}",
+            "type": "borderWidth"
+          }
+        },
+        "read-only": {
+          "background-color": {
+            "value": "{nlds.color.neutral.2}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "transparent",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.neutral.12}",
+            "type": "color"
+          }
+        },
+        "placeholder": {
+          "color": {
+            "value": "{nlds.color.neutral.9}",
+            "type": "color"
+          }
+        },
+        "border-radius": {
+          "value": "{nlds.border-radius.sm}",
+          "type": "borderRadius"
+        },
+        "font-family": {
+          "value": "{nlds.typography.font-family.heading}",
+          "type": "fontFamilies"
+        },
+        "font-size": {
+          "value": "{nlds.typography.font-size.md}",
+          "type": "fontSizes"
+        },
+        "line-height": {
+          "value": "{nlds.typography.line-height.md}",
+          "type": "lineHeights"
+        },
+        "max-inline-size": {
+          "value": "400px",
+          "type": "sizing"
+        },
+        "padding-block-end": {
+          "value": "{nlds.space.block.snail}",
+          "type": "spacing"
+        },
+        "padding-block-start": {
+          "value": "{nlds.space.block.snail}",
+          "type": "spacing"
+        },
+        "padding-inline-end": {
+          "value": "{nlds.space.inline.snail}",
+          "type": "spacing"
+        },
+        "padding-inline-start": {
+          "value": "{nlds.space.inline.snail}",
+          "type": "spacing"
+        }
+      },
+      "focus": {
+        "background-color": {
+          "value": "{nlds.color.signal.focus}",
+          "type": "color"
+        },
+        "color": {
+          "value": "{nlds.color.black}",
+          "type": "color"
+        },
+        "outline-color": {
+          "value": "{nlds.color.indigo.9}",
+          "type": "color"
+        },
+        "inverse": {
+          "outline-color": {
+            "value": "{nlds.color.white}",
+            "type": "color"
+          }
+        },
+        "outline-offset": {
+          "value": "0",
+          "type": "other"
+        },
+        "outline-style": {
+          "value": "dotted",
+          "type": "other"
+        },
+        "outline-width": {
+          "value": "{nlds.border-width.md}",
+          "type": "borderWidth"
+        }
+      },
+      "pointer-target": {
+        "min-size": {
+          "value": "{nlds.size.md}",
+          "type": "sizing"
+        }
+      },
+      "feedback": {
+        "warning": {
+          "background-color": {
+            "value": "{nlds.color.oranje.2}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{nlds.color.signal.warning.700}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.signal.warning.700}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "nlds": {
+      "root": {
+        "background-color": {
+          "value": "{nlds.color.paars.3}",
+          "type": "color"
+        }
+      },
+      "container": {
+        "border-width": {
+          "value": "{nlds.border-width.sm}",
+          "type": "borderWidth"
+        },
+        "border-color": {
+          "value": "{nlds.color.neutral.7}",
+          "type": "color"
+        }
+      },
+      "line": {
+        "border-width": {
+          "value": "{nlds.border-width.sm}",
+          "type": "borderWidth"
+        },
+        "border-color": {
+          "value": "{nlds.color.neutral.6}",
+          "type": "color"
+        }
+      },
+      "form-control": {
+        "active": {
+          "border-width": {
+            "value": "{nlds.border-width.md}",
+            "type": "borderWidth"
+          },
+          "accent-color": {
+            "value": "{nlds.interaction.active.color}",
+            "type": "color"
+          },
+          "background-color": {
+            "value": "{nlds.color.neutral.4}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{nlds.color.neutral.8}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.neutral.12}",
+            "type": "color"
+          }
+        },
+        "hover": {
+          "border-width": {
+            "value": "{nlds.border-width.md}",
+            "type": "borderWidth"
+          },
+          "accent-color": {
+            "value": "{nlds.interaction.hover.color}",
+            "type": "color"
+          },
+          "background-color": {
+            "value": "{nlds.color.neutral.2}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{nlds.color.neutral.8}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.neutral.12}",
+            "type": "color"
+          }
+        },
+        "accent-color": {
+          "value": "{nlds.interaction.color}",
+          "type": "color"
+        },
+        "disabled": {
+          "accent-color": {
+            "value": "# {nlds.color.neutral.8}",
+            "type": "color"
+          }
+        }
+      },
+      "document": {
+        "inverse": {
+          "background-color": {
+            "value": "{nlds.color.paars.12}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.neutral.accent}",
+            "type": "color"
+          }
+        },
+        "subtle": {
+          "color": {
+            "value": "{nlds.color.neutral.9}",
+            "type": "color"
+          }
+        },
+        "strong": {
+          "font-weight": {
+            "value": "{nlds.typography.font-weight.semibold}",
+            "type": "fontWeights"
+          }
+        }
+      },
+      "interaction": {
+        "color": {
+          "value": "{nlds.color.indigo.accent}",
+          "type": "color"
+        },
+        "active": {
+          "color": {
+            "value": "{nlds.color.indigo.9}",
+            "type": "color"
+          }
+        },
+        "hover": {
+          "color": {
+            "value": "{nlds.color.indigo.8}",
+            "type": "color"
+          }
+        }
+      },
+      "icon": {
+        "functional": {
+          "size": {
+            "value": "{nlds.size.icon.md}",
+            "type": "sizing"
+          }
+        },
+        "toptask": {
+          "size": {
+            "value": "{nlds.size.icon.4xl}",
+            "type": "sizing"
+          }
+        }
+      },
+      "feedback": {
+        "informative": {
+          "background-color": {
+            "value": "{nlds.color.blauw.2}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{nlds.color.blauw.8}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.blauw.8}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "background-color": {
+            "value": "{nlds.color.rood.100}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{nlds.color.signal.rood.500}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.signal.rood.500}",
+            "type": "color"
+          }
+        },
+        "positive": {
+          "background-color": {
+            "value": "{nlds.color.groen.2}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{nlds.color.signal.groen.500}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.signal.groen.500}",
+            "type": "color"
+          }
+        }
+      },
+      "space": {
+        "relation": {
+          "kind": {
+            "value": "0px",
+            "type": "dimension"
+          },
+          "besties": {
+            "value": "{nlds.space.row.snail}",
+            "type": "dimension"
+          },
+          "vrienden": {
+            "value": "{nlds.space.row.rat}",
+            "type": "dimension"
+          },
+          "bekenden": {
+            "value": "{nlds.space.row.cat}",
+            "type": "dimension"
+          },
+          "onbekenden": {
+            "value": "{nlds.space.row.pig}",
+            "type": "dimension"
+          },
+          "onbemind": {
+            "value": "{nlds.space.row.horse}",
+            "type": "dimension"
+          }
+        }
+      },
+      "code": {
+        "font-family": {
+          "value": "{nlds.typography.font-family.code}",
+          "type": "fontFamilies"
+        }
+      }
+    }
+  },
   "components/heading-4": {
     "nl": {
       "heading-4": {
@@ -5394,6 +5911,164 @@
         "line-height": {
           "value": "{nlds.typography.line-height.md}",
           "type": "lineHeights"
+        }
+      }
+    }
+  },
+  "components/accordion/utrecht": {
+    "utrecht": {
+      "accordion": {
+        "panel": {
+          "border-color": {
+            "value": "transparent",
+            "type": "color"
+          },
+          "border-width": {
+            "value": "{nlds.border-width.sm}",
+            "type": "borderWidth"
+          },
+          "padding-block-end": {
+            "value": "{nlds.space.block.rabbit}",
+            "type": "spacing"
+          },
+          "padding-block-start": {
+            "value": "{nlds.space.block.rabbit}",
+            "type": "spacing"
+          },
+          "padding-inline-end": {
+            "value": "{nlds.space.inline.mouse}",
+            "type": "spacing"
+          },
+          "padding-inline-start": {
+            "value": "{nlds.space.inline.mouse}",
+            "type": "spacing"
+          }
+        },
+        "button": {
+          "gap": {
+            "value": "{nlds.space.text.mouse}",
+            "type": "spacing"
+          },
+          "icon": {
+            "size": {
+              "value": "{nlds.icon.functional.size}",
+              "type": "sizing"
+            }
+          },
+          "padding-block-end": {
+            "value": "{nlds.space.block.snail}",
+            "type": "spacing"
+          },
+          "padding-block-start": {
+            "value": "{nlds.space.block.snail}",
+            "type": "spacing"
+          },
+          "padding-inline-end": {
+            "value": "{nlds.space.inline.mouse}",
+            "type": "spacing"
+          },
+          "padding-inline-start": {
+            "value": "{nlds.space.inline.mouse}",
+            "type": "spacing"
+          },
+          "background-color": {
+            "value": "{nlds.color.neutral.2}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "transparent",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.interaction.color}",
+            "type": "color"
+          },
+          "hover": {
+            "background-color": {
+              "value": "{nlds.color.neutral.4}",
+              "type": "color"
+            },
+            "border-color": {
+              "value": "transparent",
+              "type": "color"
+            },
+            "color": {
+              "value": "{nlds.interaction.hover.color}",
+              "type": "color"
+            }
+          },
+          "focus": {
+            "background-color": {
+              "value": "{nlds.color.signal.focus}",
+              "type": "color"
+            },
+            "border-color": {
+              "value": "transparent",
+              "type": "color"
+            },
+            "color": {
+              "value": "{utrecht.focus.color}",
+              "type": "color"
+            }
+          },
+          "active": {
+            "background-color": {
+              "value": "{nlds.color.indigo.4}",
+              "type": "color"
+            },
+            "border-color": {
+              "value": "transparent",
+              "type": "color"
+            },
+            "color": {
+              "value": "{nlds.interaction.active.color}",
+              "type": "color"
+            }
+          },
+          "border-width": {
+            "value": "{nlds.border-width.sm}",
+            "type": "borderWidth"
+          },
+          "border-radius": {
+            "value": "{nlds.border-radius.sm}",
+            "type": "borderRadius"
+          }
+        }
+      }
+    },
+    "todo": {
+      "accordion": {
+        "section": {
+          "border-width": {
+            "value": "{nlds.border-width.sm}",
+            "type": "borderWidth"
+          },
+          "border-color": {
+            "value": "{nlds.line.border-color}",
+            "type": "color"
+          }
+        },
+        "button": {
+          "font-size": {
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
+          },
+          "line-height": {
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
+          },
+          "font-family": {
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
+          },
+          "font-weight": {
+            "value": "{nlds.document.strong.font-weight}",
+            "type": "fontWeights"
+          }
+        },
+        "row-gap": {
+          "value": "0",
+          "type": "spacing"
         }
       }
     }
@@ -6394,265 +7069,6 @@
         "row-gap": {
           "value": "{nlds.space.row.rat}",
           "type": "spacing"
-        }
-      }
-    }
-  },
-  "components/side-nav/nlds": {
-    "nlds": {
-      "side-nav": {
-        "list-item": {
-          "default": {
-            "background-color": {
-              "value": "{nlds.color.white}",
-              "type": "color"
-            }
-          },
-          "active": {
-            "background-color": {
-              "value": "{nlds.color.indigo.2}",
-              "type": "color"
-            },
-            "border-color": {
-              "value": "{nlds.color.indigo.8}",
-              "type": "color"
-            }
-          },
-          "hover": {
-            "background-color": {
-              "value": "{nlds.color.indigo.5}",
-              "type": "color"
-            }
-          },
-          "content": {
-            "color": {
-              "value": "{utrecht.document.color}",
-              "type": "color"
-            }
-          },
-          "focus": {
-            "background-color": {
-              "value": "{nl.link.focus-visible.background-color}",
-              "type": "color"
-            }
-          },
-          "content-inverse": {
-            "color": {
-              "value": "{nlds.color.white}",
-              "type": "color"
-            }
-          },
-          "font-family": {
-            "value": "{utrecht.button.font-family}",
-            "type": "fontFamilies"
-          },
-          "font-weight": {
-            "active": {
-              "value": "{utrecht.button.font-weight}",
-              "type": "fontWeights"
-            },
-            "default": {
-              "value": "{nlds.typography.font-weight.normal}",
-              "type": "fontWeights"
-            },
-            "inactive": {
-              "value": "Regular",
-              "type": "fontWeights"
-            }
-          },
-          "border-width": {
-            "value": {
-              "color": "{nlds.color.indigo.8}",
-              "width": "6px",
-              "style": "solid"
-            },
-            "type": "border"
-          },
-          "border-radius": {
-            "value": "{nlds.border-radius.sm}",
-            "type": "borderRadius"
-          },
-          "level-1": {
-            "padding-inline-start": {
-              "value": "{nlds.space.inline.mouse}",
-              "type": "spacing"
-            },
-            "padding-inline-end": {
-              "value": "{nlds.space.inline.mouse}",
-              "type": "spacing"
-            }
-          },
-          "column-gap": {
-            "value": "{nlds.space.column.snail}",
-            "type": "spacing"
-          },
-          "padding-block": {
-            "value": "{nlds.space.block.mouse}",
-            "type": "spacing"
-          },
-          "level-2": {
-            "padding-inline-start": {
-              "value": "{nlds.space.inline.pig}",
-              "type": "spacing"
-            },
-            "padding-inline-end": {
-              "value": "{nlds.space.inline.mouse}",
-              "type": "spacing"
-            }
-          }
-        },
-        "background-color": {
-          "value": "{nlds.color.white}",
-          "type": "color"
-        },
-        "border-color": {
-          "value": "{nlds.container.border-color}",
-          "type": "color"
-        },
-        "line-height": {
-          "value": "125%",
-          "type": "lineHeights"
-        },
-        "border-width": {
-          "value": {
-            "color": "",
-            "width": "1px",
-            "style": "solid"
-          },
-          "type": "border"
-        },
-        "row-gap": {
-          "value": "{nlds.space.row.rat}",
-          "type": "spacing"
-        }
-      },
-      "box-shadow": {
-        "value": {
-          "x": "0",
-          "y": "0",
-          "blur": "0",
-          "spread": "0",
-          "color": "#fff",
-          "type": "innerShadow"
-        },
-        "type": "boxShadow"
-      }
-    }
-  },
-  "components/side-nav/den-haag": {
-    "denhaag": {
-      "sidenav": {
-        "min-width": {
-          "value": "240px",
-          "type": "sizing"
-        },
-        "row-gap": {
-          "value": "{nlds.space.row.cat}",
-          "type": "spacing"
-        },
-        "item": {
-          "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
-          },
-          "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
-          },
-          "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
-          },
-          "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
-          }
-        },
-        "link": {
-          "color": {
-            "value": "{nlds.interaction.color}",
-            "type": "color"
-          },
-          "column-gap": {
-            "value": "{nlds.space.text.mouse}",
-            "type": "spacing"
-          },
-          "padding-block-end": {
-            "value": "{nlds.space.block.snail}",
-            "type": "spacing"
-          },
-          "padding-block-start": {
-            "value": "{nlds.space.block.snail}",
-            "type": "spacing"
-          },
-          "text-decoration": {
-            "value": "None",
-            "type": "textDecoration"
-          },
-          "current": {
-            "font-weight": {
-              "value": "{nlds.document.strong.font-weight}",
-              "type": "fontWeights"
-            },
-            "color": {
-              "value": "{utrecht.document.color}",
-              "type": "color"
-            }
-          },
-          "active": {
-            "font-weight": {
-              "value": "{nlds.document.strong.font-weight}",
-              "type": "fontWeights"
-            },
-            "color": {
-              "value": "{nlds.interaction.active.color}",
-              "type": "color"
-            }
-          },
-          "hover": {
-            "color": {
-              "value": "{nlds.interaction.hover.color}",
-              "type": "color"
-            }
-          }
-        },
-        "list": {
-          "padding-block-end": {
-            "value": "0px",
-            "type": "spacing"
-          },
-          "padding-block-start": {
-            "value": "0px",
-            "type": "spacing"
-          },
-          "padding-inline-start": {
-            "value": "0px",
-            "type": "spacing"
-          }
-        }
-      }
-    },
-    "todo": {
-      "sidenav": {
-        "link": {
-          "focus-visible": {
-            "text-decoration": {
-              "value": "None",
-              "type": "textDecoration"
-            }
-          },
-          "hover": {
-            "text-decoration": {
-              "value": "underline",
-              "type": "textDecoration"
-            }
-          },
-          "icon": {
-            "size": {
-              "value": "{nlds.icon.functional.size}",
-              "type": "sizing"
-            }
-          }
         }
       }
     }
@@ -8767,120 +9183,6 @@
       }
     }
   },
-  "components/nlds/status-badge": {
-    "nlds": {
-      "status-badge": {
-        "font-size": {
-          "value": "{nlds.typography.font-size.sm}",
-          "type": "fontSizes"
-        },
-        "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
-        },
-        "font-weight": {
-          "value": "{nlds.document.strong.font-weight}",
-          "type": "fontWeights"
-        },
-        "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
-        },
-        "border-width": {
-          "value": "{nlds.border-width.sm}",
-          "type": "borderWidth"
-        },
-        "border-radius": {
-          "value": "{nlds.border-radius.sm}",
-          "type": "borderRadius"
-        },
-        "padding-inline": {
-          "value": "{nlds.space.inline.ant}",
-          "type": "spacing"
-        },
-        "padding-block": {
-          "value": "{nlds.space.block.flea}",
-          "type": "spacing"
-        },
-        "informative": {
-          "background-color": {
-            "value": "{utrecht.alert.info.background-color}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "transparent",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.feedback.informative.color}",
-            "type": "color"
-          }
-        },
-        "positive": {
-          "background-color": {
-            "value": "{utrecht.alert.ok.background-color}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "transparent",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.feedback.positive.color}",
-            "type": "color"
-          }
-        },
-        "negative": {
-          "background-color": {
-            "value": "{nlds.feedback.negative.background-color}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "transparent",
-            "type": "color"
-          },
-          "color": {
-            "value": "{nlds.feedback.negative.color}",
-            "type": "color"
-          }
-        },
-        "warning": {
-          "background-color": {
-            "value": "{utrecht.feedback.warning.background-color}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "transparent",
-            "type": "color"
-          },
-          "color": {
-            "value": "{utrecht.feedback.warning.color}",
-            "type": "color"
-          }
-        },
-        "background-color": {
-          "value": "{nlds.color.paars.100}",
-          "type": "color"
-        },
-        "border-color": {
-          "value": "transparent",
-          "type": "color"
-        },
-        "icon-size": {
-          "value": "{nlds.size.icon.sm}",
-          "type": "sizing"
-        },
-        "color": {
-          "value": "{utrecht.document.color}",
-          "type": "color"
-        },
-        "gap": {
-          "value": "{nlds.space.block.flea}",
-          "type": "spacing"
-        }
-      }
-    }
-  },
   "components/step-marker": {
     "denhaag": {
       "step-marker": {
@@ -10031,13 +10333,718 @@
       }
     }
   },
+  "components/accordion/nlds": {
+    "nlds": {
+      "accordion": {
+        "panel": {
+          "border-color": {
+            "value": "{nlds.line.border-color}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.color.neutral.accent}",
+            "type": "color"
+          }
+        },
+        "button": {
+          "help-wanted": {
+            "background-color": {
+              "value": "{nlds.color.oranje.accent}",
+              "type": "color"
+            },
+            "border-color": {
+              "value": "transparent",
+              "type": "color"
+            },
+            "color": {
+              "value": "{nlds.color.oranje.11}",
+              "type": "color"
+            },
+            "hover": {
+              "background-color": {
+                "value": "{nlds.color.oranje.5}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{nlds.color.oranje.12}",
+                "type": "color"
+              }
+            },
+            "focus": {
+              "background-color": {
+                "value": "{nlds.color.signal.focus}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{utrecht.focus.color}",
+                "type": "color"
+              }
+            },
+            "active": {
+              "background-color": {
+                "value": "{nlds.color.oranje.6}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{nlds.color.oranje.12}",
+                "type": "color"
+              }
+            }
+          },
+          "community": {
+            "background-color": {
+              "value": "{nlds.color.paars.accent}",
+              "type": "color"
+            },
+            "border-color": {
+              "value": "transparent",
+              "type": "color"
+            },
+            "color": {
+              "value": "{nlds.color.paars.11}",
+              "type": "color"
+            },
+            "hover": {
+              "background-color": {
+                "value": "{nlds.color.paars.5}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{nlds.color.paars.12}",
+                "type": "color"
+              }
+            },
+            "focus": {
+              "background-color": {
+                "value": "{nlds.color.signal.focus}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{utrecht.focus.color}",
+                "type": "color"
+              }
+            },
+            "active": {
+              "background-color": {
+                "value": "{nlds.color.paars.6}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{nlds.color.paars.12}",
+                "type": "color"
+              }
+            }
+          },
+          "candidate": {
+            "background-color": {
+              "value": "{nlds.color.blauw.accent}",
+              "type": "color"
+            },
+            "border-color": {
+              "value": "transparent",
+              "type": "color"
+            },
+            "color": {
+              "value": "{nlds.color.blauw.11}",
+              "type": "color"
+            },
+            "hover": {
+              "background-color": {
+                "value": "{nlds.color.blauw.5}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{nlds.color.blauw.12}",
+                "type": "color"
+              }
+            },
+            "focus": {
+              "background-color": {
+                "value": "{nlds.color.signal.focus}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{utrecht.focus.color}",
+                "type": "color"
+              }
+            },
+            "active": {
+              "background-color": {
+                "value": "{nlds.color.blauw.6}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{nlds.color.blauw.12}",
+                "type": "color"
+              }
+            }
+          },
+          "hall-of-fame": {
+            "background-color": {
+              "value": "{nlds.color.groen.accent}",
+              "type": "color"
+            },
+            "border-color": {
+              "value": "transparent",
+              "type": "color"
+            },
+            "color": {
+              "value": "{nlds.color.groen.11}",
+              "type": "color"
+            },
+            "hover": {
+              "background-color": {
+                "value": "{nlds.color.groen.5}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{nlds.color.groen.12}",
+                "type": "color"
+              }
+            },
+            "focus": {
+              "background-color": {
+                "value": "{nlds.color.signal.focus}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{utrecht.focus.color}",
+                "type": "color"
+              }
+            },
+            "active": {
+              "background-color": {
+                "value": "{nlds.color.groen.6}",
+                "type": "color"
+              },
+              "border-color": {
+                "value": "transparent",
+                "type": "color"
+              },
+              "color": {
+                "value": "{nlds.color.groen.12}",
+                "type": "color"
+              }
+            }
+          },
+          "font-size": {
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
+          },
+          "line-height": {
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
+          },
+          "font-family": {
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
+          },
+          "font-weight": {
+            "value": "{nlds.document.strong.font-weight}",
+            "type": "fontWeights"
+          }
+        },
+        "section": {
+          "border-width": {
+            "value": "{nlds.border-width.sm}",
+            "type": "borderWidth"
+          },
+          "border-color": {
+            "value": "{nlds.color.neutral.accent}",
+            "type": "color"
+          }
+        },
+        "row-gap": {
+          "value": "0",
+          "type": "spacing"
+        }
+      }
+    },
+    "utrecht": {
+      "accordion": {
+        "panel": {
+          "border-width": {
+            "value": "{nlds.border-width.sm}",
+            "type": "borderWidth"
+          },
+          "padding-block-end": {
+            "value": "{nlds.space.block.rabbit}",
+            "type": "spacing"
+          },
+          "padding-block-start": {
+            "value": "{nlds.space.block.rabbit}",
+            "type": "spacing"
+          },
+          "padding-inline-end": {
+            "value": "{nlds.space.inline.mouse}",
+            "type": "spacing"
+          },
+          "padding-inline-start": {
+            "value": "{nlds.space.inline.mouse}",
+            "type": "spacing"
+          }
+        },
+        "button": {
+          "gap": {
+            "value": "{nlds.space.text.mouse}",
+            "type": "spacing"
+          },
+          "icon": {
+            "size": {
+              "value": "{nlds.icon.functional.size}",
+              "type": "sizing"
+            }
+          },
+          "padding-block-end": {
+            "value": "{nlds.space.block.snail}",
+            "type": "spacing"
+          },
+          "padding-block-start": {
+            "value": "{nlds.space.block.snail}",
+            "type": "spacing"
+          },
+          "padding-inline-end": {
+            "value": "{nlds.space.inline.mouse}",
+            "type": "spacing"
+          },
+          "padding-inline-start": {
+            "value": "{nlds.space.inline.mouse}",
+            "type": "spacing"
+          },
+          "border-width": {
+            "value": "{nlds.border-width.sm}",
+            "type": "borderWidth"
+          },
+          "border-radius": {
+            "value": "{nlds.border-radius.sm}",
+            "type": "borderRadius"
+          }
+        }
+      }
+    }
+  },
+  "components/side-nav/nlds": {
+    "nlds": {
+      "side-nav": {
+        "list-item": {
+          "default": {
+            "background-color": {
+              "value": "{nlds.color.white}",
+              "type": "color"
+            }
+          },
+          "active": {
+            "background-color": {
+              "value": "{nlds.color.indigo.2}",
+              "type": "color"
+            },
+            "border-color": {
+              "value": "{nlds.color.indigo.8}",
+              "type": "color"
+            }
+          },
+          "hover": {
+            "background-color": {
+              "value": "{nlds.color.indigo.5}",
+              "type": "color"
+            }
+          },
+          "content": {
+            "color": {
+              "value": "{utrecht.document.color}",
+              "type": "color"
+            }
+          },
+          "focus": {
+            "background-color": {
+              "value": "{nl.link.focus-visible.background-color}",
+              "type": "color"
+            }
+          },
+          "content-inverse": {
+            "color": {
+              "value": "{nlds.color.white}",
+              "type": "color"
+            }
+          },
+          "font-family": {
+            "value": "{utrecht.button.font-family}",
+            "type": "fontFamilies"
+          },
+          "font-weight": {
+            "active": {
+              "value": "{utrecht.button.font-weight}",
+              "type": "fontWeights"
+            },
+            "default": {
+              "value": "{nlds.typography.font-weight.normal}",
+              "type": "fontWeights"
+            },
+            "inactive": {
+              "value": "Regular",
+              "type": "fontWeights"
+            }
+          },
+          "border-width": {
+            "value": {
+              "color": "{nlds.color.indigo.8}",
+              "width": "6px",
+              "style": "solid"
+            },
+            "type": "border"
+          },
+          "border-radius": {
+            "value": "{nlds.border-radius.sm}",
+            "type": "borderRadius"
+          },
+          "level-1": {
+            "padding-inline-start": {
+              "value": "{nlds.space.inline.mouse}",
+              "type": "spacing"
+            },
+            "padding-inline-end": {
+              "value": "{nlds.space.inline.mouse}",
+              "type": "spacing"
+            }
+          },
+          "column-gap": {
+            "value": "{nlds.space.column.snail}",
+            "type": "spacing"
+          },
+          "padding-block": {
+            "value": "{nlds.space.block.mouse}",
+            "type": "spacing"
+          },
+          "level-2": {
+            "padding-inline-start": {
+              "value": "{nlds.space.inline.pig}",
+              "type": "spacing"
+            },
+            "padding-inline-end": {
+              "value": "{nlds.space.inline.mouse}",
+              "type": "spacing"
+            }
+          }
+        },
+        "background-color": {
+          "value": "{nlds.color.white}",
+          "type": "color"
+        },
+        "border-color": {
+          "value": "{nlds.container.border-color}",
+          "type": "color"
+        },
+        "line-height": {
+          "value": "125%",
+          "type": "lineHeights"
+        },
+        "border-width": {
+          "value": {
+            "color": "",
+            "width": "1px",
+            "style": "solid"
+          },
+          "type": "border"
+        },
+        "row-gap": {
+          "value": "{nlds.space.row.rat}",
+          "type": "spacing"
+        }
+      },
+      "box-shadow": {
+        "value": {
+          "x": "0",
+          "y": "0",
+          "blur": "0",
+          "spread": "0",
+          "color": "#fff",
+          "type": "innerShadow"
+        },
+        "type": "boxShadow"
+      }
+    }
+  },
+  "components/side-nav/den-haag": {
+    "denhaag": {
+      "sidenav": {
+        "min-width": {
+          "value": "240px",
+          "type": "sizing"
+        },
+        "row-gap": {
+          "value": "{nlds.space.row.cat}",
+          "type": "spacing"
+        },
+        "item": {
+          "font-family": {
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
+          },
+          "font-size": {
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
+          },
+          "font-weight": {
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
+          },
+          "line-height": {
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
+          }
+        },
+        "link": {
+          "color": {
+            "value": "{nlds.interaction.color}",
+            "type": "color"
+          },
+          "column-gap": {
+            "value": "{nlds.space.text.mouse}",
+            "type": "spacing"
+          },
+          "padding-block-end": {
+            "value": "{nlds.space.block.snail}",
+            "type": "spacing"
+          },
+          "padding-block-start": {
+            "value": "{nlds.space.block.snail}",
+            "type": "spacing"
+          },
+          "text-decoration": {
+            "value": "None",
+            "type": "textDecoration"
+          },
+          "current": {
+            "font-weight": {
+              "value": "{nlds.document.strong.font-weight}",
+              "type": "fontWeights"
+            },
+            "color": {
+              "value": "{utrecht.document.color}",
+              "type": "color"
+            }
+          },
+          "active": {
+            "font-weight": {
+              "value": "{nlds.document.strong.font-weight}",
+              "type": "fontWeights"
+            },
+            "color": {
+              "value": "{nlds.interaction.active.color}",
+              "type": "color"
+            }
+          },
+          "hover": {
+            "color": {
+              "value": "{nlds.interaction.hover.color}",
+              "type": "color"
+            }
+          }
+        },
+        "list": {
+          "padding-block-end": {
+            "value": "0px",
+            "type": "spacing"
+          },
+          "padding-block-start": {
+            "value": "0px",
+            "type": "spacing"
+          },
+          "padding-inline-start": {
+            "value": "0px",
+            "type": "spacing"
+          }
+        }
+      }
+    },
+    "todo": {
+      "sidenav": {
+        "link": {
+          "focus-visible": {
+            "text-decoration": {
+              "value": "None",
+              "type": "textDecoration"
+            }
+          },
+          "hover": {
+            "text-decoration": {
+              "value": "underline",
+              "type": "textDecoration"
+            }
+          },
+          "icon": {
+            "size": {
+              "value": "{nlds.icon.functional.size}",
+              "type": "sizing"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components/nlds/status-badge": {
+    "nlds": {
+      "status-badge": {
+        "font-size": {
+          "value": "{nlds.typography.font-size.sm}",
+          "type": "fontSizes"
+        },
+        "line-height": {
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
+        },
+        "font-weight": {
+          "value": "{nlds.document.strong.font-weight}",
+          "type": "fontWeights"
+        },
+        "font-family": {
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
+        },
+        "border-width": {
+          "value": "{nlds.border-width.sm}",
+          "type": "borderWidth"
+        },
+        "border-radius": {
+          "value": "{nlds.border-radius.sm}",
+          "type": "borderRadius"
+        },
+        "padding-inline": {
+          "value": "{nlds.space.inline.ant}",
+          "type": "spacing"
+        },
+        "padding-block": {
+          "value": "{nlds.space.block.flea}",
+          "type": "spacing"
+        },
+        "informative": {
+          "background-color": {
+            "value": "{utrecht.alert.info.background-color}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "transparent",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.feedback.informative.color}",
+            "type": "color"
+          }
+        },
+        "positive": {
+          "background-color": {
+            "value": "{utrecht.alert.ok.background-color}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "transparent",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.feedback.positive.color}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "background-color": {
+            "value": "{nlds.feedback.negative.background-color}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "transparent",
+            "type": "color"
+          },
+          "color": {
+            "value": "{nlds.feedback.negative.color}",
+            "type": "color"
+          }
+        },
+        "warning": {
+          "background-color": {
+            "value": "{utrecht.feedback.warning.background-color}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "transparent",
+            "type": "color"
+          },
+          "color": {
+            "value": "{utrecht.feedback.warning.color}",
+            "type": "color"
+          }
+        },
+        "background-color": {
+          "value": "{nlds.color.paars.100}",
+          "type": "color"
+        },
+        "border-color": {
+          "value": "transparent",
+          "type": "color"
+        },
+        "icon-size": {
+          "value": "{nlds.size.icon.sm}",
+          "type": "sizing"
+        },
+        "color": {
+          "value": "{utrecht.document.color}",
+          "type": "color"
+        },
+        "gap": {
+          "value": "{nlds.space.block.flea}",
+          "type": "spacing"
+        }
+      }
+    }
+  },
   "$themes": [],
   "$metadata": {
     "tokenSetOrder": [
       "brand",
-      "common",
-      "components/accordion/utrecht",
-      "components/accordion/nlds",
+      "components/brand",
       "components/action",
       "components/alert",
       "components/avatar",
@@ -10071,7 +11078,9 @@
       "components/heading-1",
       "components/heading-2",
       "components/heading-3",
+      "common",
       "components/heading-4",
+      "components/accordion/utrecht",
       "components/heading-5",
       "components/heading-6",
       "components/heading-group",
@@ -10085,8 +11094,6 @@
       "components/modal-dialog",
       "components/number-badge",
       "components/navigation-bar",
-      "components/side-nav/nlds",
-      "components/side-nav/den-haag",
       "components/ordered-list",
       "components/page-number-navigation",
       "components/page-footer",
@@ -10100,7 +11107,6 @@
       "components/separator",
       "components/skip-link",
       "components/status-badge",
-      "components/nlds/status-badge",
       "components/step-marker",
       "components/switch",
       "components/table",
@@ -10109,7 +11115,11 @@
       "components/text-input",
       "components/toolbar-button",
       "components/file-input",
-      "components/unordered-list"
+      "components/unordered-list",
+      "components/accordion/nlds",
+      "components/side-nav/nlds",
+      "components/side-nav/den-haag",
+      "components/nlds/status-badge"
     ]
   }
 }


### PR DESCRIPTION
Components/brand toegevoegd als een work-around omdat de Automater plug-in momenteel niet werkt met Token Studio. Op deze manier kan ik toch snel de kleuren documenteren.